### PR TITLE
Add Python 3.13 and 3.14 on CI and use supported Intel macOS runner

### DIFF
--- a/.github/workflows/tox.yml
+++ b/.github/workflows/tox.yml
@@ -2,6 +2,9 @@ name: Tox
 
 on: [push, pull_request, workflow_dispatch]
 
+permissions:
+  contents: read
+
 jobs:
   tox:
     strategy:

--- a/.github/workflows/tox.yml
+++ b/.github/workflows/tox.yml
@@ -59,3 +59,23 @@ jobs:
 
     - name: Check with tox
       run: tox
+
+  all-pass:
+    name: All tox checks pass
+
+    needs: [tox]
+
+    # Don't skip `all-pass` on cancellation, since a skipped required check won't block auto-merge.
+    if: always()
+
+    runs-on: ubuntu-latest
+
+    steps:
+    - name: Some failed
+      if: contains(needs.*.result, 'cancelled') || contains(needs.*.result, 'failure')
+      run: |
+        false
+
+    - name: All passed
+      run: |
+        true

--- a/.github/workflows/tox.yml
+++ b/.github/workflows/tox.yml
@@ -9,10 +9,10 @@ jobs:
         os:
         - ubuntu-22.04  # Used only for testing Python 3.7.
         - ubuntu-latest
-        - macos-13
+        - macos-15-intel
         - macos-latest
         - windows-latest
-        python-version: ['3.7', '3.8', '3.9', '3.10', '3.11', '3.12']
+        python-version: ['3.7', '3.8', '3.9', '3.10', '3.11', '3.12', '3.13', '3.14']
         exclude:
         # Exclude unnecessary Ubuntu 22.04 runs.
         - os: ubuntu-22.04
@@ -25,6 +25,10 @@ jobs:
           python-version: '3.11'
         - os: ubuntu-22.04
           python-version: '3.12'
+        - os: ubuntu-22.04
+          python-version: '3.13'
+        - os: ubuntu-22.04
+          python-version: '3.14'
         # Exclude builds that are not currently available.
         - os: ubuntu-latest
           python-version: '3.7'

--- a/tox.ini
+++ b/tox.ini
@@ -1,7 +1,7 @@
 [tox]
 requires = tox>=4
 skip_missing_interpreters = false
-env_list = ruff{,-format}, {,mypy-,pyright-}py{37,38,39,310,311,312}
+env_list = ruff{,-format}, {,mypy-,pyright-}py{37,38,39,310,311,312,313,314}
 
 [gh-actions]
 python =
@@ -10,7 +10,9 @@ python =
     3.9: {,mypy-,pyright-}py39
     3.10: {,mypy-,pyright-}py310
     3.11: {,mypy-,pyright-}py311
-    3.12: ruff{,-format}, {,mypy-,pyright-}py312
+    3.12: {,mypy-,pyright-}py312
+    3.13: {,mypy-,pyright-}py313
+    3.14: ruff{,-format}, {,mypy-,pyright-}py314
 
 [testenv]
 description = Run unit tests
@@ -20,25 +22,25 @@ commands = pytest --color=yes -vv {posargs}
 
 [testenv:ruff]
 description = Lint with Ruff
-base_python = py312
+base_python = py314
 set_env =
     CLICOLOR_FORCE = 1  # Set NO_COLOR to override this.
 commands = ruff check .
 
 [testenv:ruff-format]
 description = Check formatting with Ruff
-base_python = py312
+base_python = py314
 set_env =
     CLICOLOR_FORCE = 1  # Set NO_COLOR to override this.
 commands = ruff format --check .
 
-[testenv:mypy-py{37,38,39,310,311,312}]
+[testenv:mypy-py{37,38,39,310,311,312,313,314}]
 description = Typecheck with mypy
 commands =
     python -V
     mypy
 
-[testenv:pyright-py{37,38,39,310,311,312}]
+[testenv:pyright-py{37,38,39,310,311,312,313,314}]
 description = Typecheck with pyright
 extras = typecheck
 commands =


### PR DESCRIPTION
On using `macos-15-intel` instead of `macos-13`, see: https://github.com/actions/runner-images/issues/13046

Here's a CI run in this repo showing `macos-13` is unavailable: https://github.com/EliahKagan/GitPython-static-dynamic/actions/runs/20081000739